### PR TITLE
Fixes the previous story note showing issue

### DIFF
--- a/src/client/components/react/book.tsx
+++ b/src/client/components/react/book.tsx
@@ -28,7 +28,7 @@ const Book = ({ stories }: { stories: Story[] }) => {
   const id = '' + activeStoryIdx + activeStoryChapterIdx
 
   const handleChapterSelect = (storyIdx: number, chapterIdx: number) => {
-    metaContentsRef.current = story.metas
+    metaContentsRef.current = stories[storyIdx].chapters[chapterIdx].metas
     setActiveStoryIdx(storyIdx)
     setActiveStoryChapterIdx(chapterIdx)
   }


### PR DESCRIPTION
When click on a story shows the previously selected story note. Updating the story inside `handleChapterSelect` event fixes the issue.